### PR TITLE
Making PPM configurable via settings

### DIFF
--- a/satnogsclient/receiver.py
+++ b/satnogsclient/receiver.py
@@ -61,7 +61,7 @@ class SignalReceiver():
         self.observation_id = observation_id
         self.frequency = frequency
         self.decoding = kwargs.get('decoding', None)
-        self.ppm_error = kwargs.get('ppm_error', 0)  # sliding error of receiver
+        self.ppm_error = settings.PPM_ERROR  # sliding error of receiver
         self.pcm_demodulator = kwargs.get('demodulator', 'AFSK1200')
         self.modulation = kwargs.get('modulation', 'fm')  # mode of received signal
         self.sample_rate = kwargs.get('sample_rate', 22050)  # sample rate for rtl_fm output

--- a/satnogsclient/settings.py
+++ b/satnogsclient/settings.py
@@ -45,6 +45,8 @@ ROT_PORT = int(environ.get('SATNOGS_ROT_PORT', 4533))
 RIG_IP = environ.get('SATNOGS_RIG_IP', '127.0.0.1')
 RIG_PORT = int(environ.get('SATNOGS_RIG_PORT', 4532))
 
+PPM_ERROR = float(environ.get('SATNOGS_PPM_ERROR', 0))
+
 # Logging configuration
 DEFAULT_LOGGING = {
     'version': 1,


### PR DESCRIPTION
Simple change that makes PPM a configuration item like the rest of
the client settings, so users do not need to touch the code or
recompile to adjust the PPM.  Now set via the SATNOGS_PPM_ERROR
environment variable.
