### PR TITLE
match environment variable names to message

### DIFF
--- a/satnogsclient/__init__.py
+++ b/satnogsclient/__init__.py
@@ -3,8 +3,8 @@ from os import environ
 
 from validators.url import url
 
-from satnogsclient.settings import (API_TOKEN, DEFAULT_LOGGING, GROUND_STATION_ID,
-                                    GROUND_STATION_LAT, GROUND_STATION_LON, GROUND_STATION_ELEV,
+from satnogsclient.settings import (API_TOKEN, DEFAULT_LOGGING, SATNOGS_STATION_ID,
+                                    SATNOGS_STATION_LAT, SATNOGS_STATION_LON, SATNOGS_STATION_ELEV,
                                     NETWORK_API_URL)
 
 
@@ -15,17 +15,17 @@ if not environ.get('READTHEDOCS', False):
     except:
         raise Exception('Invalid NETWORK_API_URL: {0}'.format(NETWORK_API_URL))
 
-    if not GROUND_STATION_ID:
-        raise Exception('GROUND_STATION_ID not configured.')
+    if not SATNOGS_STATION_ID:
+        raise Exception('SATNOGS_STATION_ID not configured.')
 
-    if not GROUND_STATION_LAT:
-        raise Exception('GROUND_STATION_LAT not configured')
+    if not SATNOGS_STATION_LAT:
+        raise Exception('SATNOGS_STATION_LAT not configured')
 
-    if not GROUND_STATION_LON:
-        raise Exception('GROUND_STATION_LON not configured')
+    if not SATNOGS_STATION_LON:
+        raise Exception('SATNOGS_STATION_LON not configured')
 
-    if GROUND_STATION_ELEV is None:
-        raise Exception('GROUND_STATION_ELEV not configured')
+    if SATNOGS_STATION_ELEV is None:
+        raise Exception('SATNOGS_STATION_ELEV not configured')
 
     if not API_TOKEN:
         raise Exception('API_TOKEN not configured')

--- a/satnogsclient/scheduler/tasks.py
+++ b/satnogsclient/scheduler/tasks.py
@@ -29,9 +29,9 @@ def spawn_observer(*args, **kwargs):
 
     observer = Observer()
     observer.location = {
-        'lon': settings.GROUND_STATION_LON,
-        'lat': settings.GROUND_STATION_LAT,
-        'elev': settings.GROUND_STATION_ELEV
+        'lon': settings.SATNOGS_STATION_LON,
+        'lat': settings.SATNOGS_STATION_LAT,
+        'elev': settings.SATNOGS_STATION_ELEV
     }
 
     setup_kwargs = {
@@ -102,7 +102,7 @@ def post_data():
 def get_jobs():
     """Query SatNOGS Network API to GET jobs."""
     url = urljoin(settings.NETWORK_API_URL, 'jobs/')
-    params = {'ground_station': settings.GROUND_STATION_ID}
+    params = {'ground_station': settings.SATNOGS_STATION_ID}
     headers = {'Authorization': 'Token {0}'.format(settings.API_TOKEN)}
     logger.debug('URL: {0}'.format(url))
     logger.debug('Params: {0}'.format(params))

--- a/satnogsclient/settings.py
+++ b/satnogsclient/settings.py
@@ -12,10 +12,10 @@ def _cast_or_none(func, value):
 
 # Ground station information
 API_TOKEN = environ.get('SATNOGS_API_TOKEN', None)
-GROUND_STATION_ID = _cast_or_none(int, environ.get('SATNOGS_STATION_ID', None))
-GROUND_STATION_LAT = _cast_or_none(float, environ.get('SATNOGS_STATION_LAT', None))
-GROUND_STATION_LON = _cast_or_none(float, environ.get('SATNOGS_STATION_LON', None))
-GROUND_STATION_ELEV = _cast_or_none(float, environ.get('SATNOGS_STATION_ELEV', None))
+SATNOGS_STATION_ID = _cast_or_none(int, environ.get('SATNOGS_STATION_ID', None))
+SATNOGS_STATION_LAT = _cast_or_none(float, environ.get('SATNOGS_STATION_LAT', None))
+SATNOGS_STATION_LON = _cast_or_none(float, environ.get('SATNOGS_STATION_LON', None))
+SATNOGS_STATION_ELEV = _cast_or_none(float, environ.get('SATNOGS_STATION_ELEV', None))
 
 # Output paths
 APP_PATH = environ.get('SATNOGS_APP_PATH', '/tmp/.satnogs')


### PR DESCRIPTION
Match the environment variable names to the ones thrown as
exceptions.

fixes #74


<!---
@huboard:{"order":203.0203,"milestone_order":88,"custom_state":"archived"}
-->
