### PR TITLE
Configurable device for arecord

### DIFF
--- a/satnogsclient/receiver.py
+++ b/satnogsclient/receiver.py
@@ -113,6 +113,8 @@ class SignalReceiver():
                 '-r': '24000',
                 '-t': 'raw'
             }
+            if settings.ARECORD_DEVICE is not None:
+                params['-D'] = settings.ARECORD_DEVICE
         else:
             params = {
                 '-f': self.frequency,

--- a/satnogsclient/settings.py
+++ b/satnogsclient/settings.py
@@ -32,6 +32,7 @@ DEFAULT_SQLITE_PATH = path.join(APP_PATH, 'jobs.sqlite')
 SQLITE_URL = environ.get('SATNOGS_SQLITE_URL', 'sqlite:///' + DEFAULT_SQLITE_PATH)
 
 HARDWARE_RADIO = bool(strtobool(environ.get('SATNOGS_HARDWARE_RADIO', 'False')))
+ARECORD_DEVICE = _cast_or_none(str, environ.get('SATNOGS_ARECORD_DEVICE', None))
 USE_ROTATOR = bool(strtobool(environ.get('SATNOGS_USE_ROTATOR', 'True')))
 DEMODULATION_COMMAND = environ.get('SATNOGS_DEMODULATION_COMMAND', 'rtl_fm')
 ENCODING_COMMAND = environ.get('SATNOGS_ENCODING_COMMAND', 'oggenc')


### PR DESCRIPTION
When using SATNOGS_HARDWARE_RADIO combined with
SATNOGS_DEMODULATOR_COMMAND (which assumes arecord for a hardware
radio), many people may need to set a device identifier for
arecord to use. This provides such an option if it is given.

Required for v0.2.5

continued fix for satnogs/satnogs-client#66
