### PR TITLE
Prevent multiple jobs running concurrently

### DIFF
--- a/satnogsclient/scheduler/__init__.py
+++ b/satnogsclient/scheduler/__init__.py
@@ -18,7 +18,7 @@ executors = {
 
 job_defaults = {
     'coalesce': True,
-    'max_instances': 3,
+    'max_instances': 1,
     'misfire_grace_time': 5
 }
 


### PR DESCRIPTION
Previously, for some unknown reason when the observation task in
the client started, the client would attempt 2 instances of rtl_fm
and sometimes 2 instances of oggenc. In the case of a second
instance of rtl_fm it dies out quickly because the USB device is
already taken. In the case of a second oggenc, it will result in a
file with 0 bites overwriting the file with the actual data, which
the client will stash in /data/incomplete/.

I do not know why appscheduler starts 2 instances, I've checked
the jobs db and there is truly only one job per task. Seems to be
a common issue with appscheduler for differing reasons though. A
quick fix for this is to limit the number of job instances to 1.
There should be no reason why we would run multiple decoding_cmd's
or multiple demodulation_cmd's at the same time. In testing, I
have not reproduced the problem after dropping this setting to 1.
