### PR TITLE
fix client to work with new network-dev api

### DIFF
--- a/satnogsclient/scheduler/tasks.py
+++ b/satnogsclient/scheduler/tasks.py
@@ -129,7 +129,7 @@ def get_jobs():
     sock = Commsocket('127.0.0.1', settings.TASK_FEEDER_TCP_PORT)
 
     tasks = []
-    for obj in response.json():
+    for obj in response.json()['results']:
         tasks.append(obj)
         start = parser.parse(obj['start'])
         job_id = str(obj['id'])


### PR DESCRIPTION
Previously, /api/jobs/ from the network would return a list. Now, in network-dev, it returns a dict with that list inside one of the objects.

This fix allows the development builds for the client to continue working, however they will not work against network prod until that is brought up to speed.

(h/t to SM0ULC for pointing out the bug)

<!---
@huboard:{"custom_state":"archived"}
-->
