### PR TITLE
Convert wav to ogg in case of audio output #209

### DIFF
--- a/satnogsclient/observer/observer.py
+++ b/satnogsclient/observer/observer.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 import logging
+import os
+
+from datetime import datetime
+from time import sleep
+from subprocess import call
 from satnogsclient import settings
 from satnogsclient.observer.worker import WorkerFreq, WorkerTrack
 from satnogsclient.upsat import gnuradio_handler
+
 logger = logging.getLogger('satnogsclient')
 
 
@@ -15,6 +21,10 @@ class Observer:
 
     _location = None
     _gnu_proc = None
+
+    _observation_raw_file = None
+    _observation_temp_ogg_file = None
+    _observation_ogg_file = None
 
     _rot_ip = settings.ROT_IP
     _rot_port = settings.ROT_PORT
@@ -99,6 +109,30 @@ class Observer:
     def frequency(self, frequency):
         self._frequency = frequency
 
+    @property
+    def observation_raw_file(self):
+        return self._observation_raw_file
+
+    @observation_raw_file.setter
+    def observation_raw_file(self, observation_raw_file):
+        self._observation_raw_file = observation_raw_file
+
+    @property
+    def observation_temp_ogg_file(self):
+        return self._observation_temp_ogg_file
+
+    @observation_temp_ogg_file.setter
+    def observation_temp_ogg_file(self, observation_temp_ogg_file):
+        self._observation_temp_ogg_file = observation_temp_ogg_file
+
+    @property
+    def observation_ogg_file(self):
+        return self._observation_ogg_file
+
+    @observation_ogg_file.setter
+    def observation_ogg_file(self, observation_ogg_file):
+        self._observation_ogg_file = observation_ogg_file
+
     def setup(self, observation_id, tle, observation_end, frequency):
         """
         Sets up required internal variables.
@@ -111,19 +145,56 @@ class Observer:
         self.tle = tle
         self.observation_end = observation_end
         self.frequency = frequency
-        return all([self.observation_id, self.tle, self.observation_end, self.frequency])
+
+        not_completed_prefix = 'receiving_satnogs'
+        completed_prefix = 'satnogs'
+        timestamp = datetime.utcnow().strftime('%Y-%m-%dT%H-%M-%S%z')
+        raw_file_extension = 'out'
+        encoded_file_extension = 'ogg'
+        self.observation_raw_file = '{0}/{1}_{2}_{3}.{4}'.format(
+            settings.OUTPUT_PATH,
+            not_completed_prefix,
+            self.observation_id,
+            timestamp, raw_file_extension)
+        self.observation_temp_ogg_file = '{0}/{1}_{2}_{3}.{4}'.format(
+            settings.OUTPUT_PATH,
+            not_completed_prefix,
+            self.observation_id,
+            timestamp,
+            encoded_file_extension)
+        self.observation_ogg_file = '{0}/{1}_{2}_{3}.{4}'.format(
+            settings.OUTPUT_PATH,
+            completed_prefix,
+            self.observation_id,
+            timestamp,
+            encoded_file_extension)
+
+        return all([self.observation_id, self.tle,
+                    self.observation_end, self.frequency,
+                    self.observation_raw_file,
+                    self.observation_temp_ogg_file,
+                    self.observation_ogg_file])
 
     def observe(self):
         """Starts threads for rotcrl and rigctl."""
         # start thread for rotctl
         logger.info('Start gnuradio thread.')
-        self._gnu_proc = gnuradio_handler.exec_gnuradio(self.observation_id, self.frequency)
+        self._gnu_proc = gnuradio_handler.exec_gnuradio(
+            self.observation_raw_file,
+            self.frequency)
         logger.info('Start rotctrl thread.')
         self.run_rot()
 
         # start thread for rigctl
         logger.info('Start rigctrl thread.')
         self.run_rig()
+        # Polling gnuradio process status
+        self.poll_gnu_proc_status()
+        if "satnogs_fm_demod.py" in settings.GNURADIO_SCRIPT_FILENAME:
+            logger.info('Start encoding to ogg.')
+            self.ogg_enc()
+            logger.info('Rename encoded file for uploading.')
+            self.rename_ogg_file()
 
     def run_rot(self):
         self.tracker_rot = WorkerTrack(ip=self.rot_ip,
@@ -146,3 +217,30 @@ class Observer:
         logger.debug('Observation end: {0}'.format(self.observation_end))
         self.tracker_freq.trackobject(self.location, self.tle)
         self.tracker_freq.trackstart(5006, False)
+
+    def poll_gnu_proc_status(self):
+        while self._gnu_proc.poll() is None:
+            sleep(30)
+        logger.info('Observation Finished')
+
+    def remove_raw_file(self):
+        if os.path.isfile(self.observation_raw_file):
+            os.remove(self.observation_raw_file)
+
+    def ogg_enc(self):
+        if os.path.isfile(self.observation_raw_file):
+            encoded = call(["oggenc", "-r",
+                            "--raw-endianness", "0",
+                            "-R", "44100", "-B", "16", "-C", "1",
+                            "-q", "10", "-o",
+                            self.observation_temp_ogg_file,
+                            self.observation_raw_file])
+            logger.info('Encoding Finished')
+            if encoded == 0 and settings.REMOVE_RAW_FILES:
+                self.remove_raw_file()
+
+    def rename_ogg_file(self):
+        if os.path.isfile(self.observation_temp_ogg_file):
+            os.rename(self.observation_temp_ogg_file,
+                      self.observation_ogg_file)
+        logger.info('Rename encoded file for uploading finished')

--- a/satnogsclient/settings.py
+++ b/satnogsclient/settings.py
@@ -33,6 +33,8 @@ for p in [APP_PATH, OUTPUT_PATH, COMPLETE_OUTPUT_PATH, INCOMPLETE_OUTPUT_PATH]:
     if not os.path.exists(p):
         os.mkdir(p)
 
+REMOVE_RAW_FILES = environ.get("SATNOGS_REMOVE_RAW_FILES, 'True'")
+
 VERIFY_SSL = bool(strtobool(environ.get('SATNOGS_VERIFY_SSL', 'True')))
 DEFAULT_SQLITE_PATH = path.join(APP_PATH, 'jobs.sqlite')
 SQLITE_URL = environ.get('SATNOGS_SQLITE_URL', 'sqlite:///' + DEFAULT_SQLITE_PATH)

--- a/satnogsclient/upsat/gnuradio_handler.py
+++ b/satnogsclient/upsat/gnuradio_handler.py
@@ -47,10 +47,10 @@ def read_from_gnuradio():
             logger.error('Ecss Dictionary not properly constructed. Error occured. Key \'ser_type\' not in dictionary')
 
 
-def exec_gnuradio(observation_id, freq):
-    arguments = {'filename': client_settings.OUTPUT_PATH + '/' + str(observation_id),
-                                                    'rx_device': client_settings.RX_DEVICE,
-                                                    'center_freq': str(freq)}
+def exec_gnuradio(observation_file, freq):
+    arguments = {'filename': observation_file,
+                 'rx_device': client_settings.RX_DEVICE,
+                 'center_freq': str(freq)}
     arg_string = ' '
     arg_string += '--rx-sdr-device=' + arguments['rx_device'] + ' '
     arg_string += '--file-path=' + arguments['filename'] + ' '


### PR DESCRIPTION
By the end of an observation and if the selected gnuradio
script is "satnogs_fm_demod.py" the raw (audio) observation file
is encoded to ogg file.

After encoding, the encoded file is renamed appropriately in order
to be uploaded to network by the client.

Depending on the value of REMOVE_RAW_FILES setting (default: True)
client removes or not the raw audio file.

<!---
@huboard:{"custom_state":"archived"}
-->
