### PR TITLE
Generate and plot waterfall

### DIFF
--- a/satnogsclient/scheduler/tasks.py
+++ b/satnogsclient/scheduler/tasks.py
@@ -84,6 +84,12 @@ def post_data():
         # Ignore files in receiving state
         if f.startswith('receiving'):
             continue
+
+        # temporary skip of waterfall until we integrate with Network
+        # TODO replace with network API code for waterfall
+        if f.startswith('waterfall'):
+            continue
+
         observation_id = f.split('_')[1]
         logger.info('Trying to PUT observation data for id: {0}'.format(observation_id))
         file_path = os.path.join(*[settings.OUTPUT_PATH, f])

--- a/satnogsclient/upsat/gnuradio_handler.py
+++ b/satnogsclient/upsat/gnuradio_handler.py
@@ -47,13 +47,15 @@ def read_from_gnuradio():
             logger.error('Ecss Dictionary not properly constructed. Error occured. Key \'ser_type\' not in dictionary')
 
 
-def exec_gnuradio(observation_file, freq):
+def exec_gnuradio(observation_file, waterfall_file, freq):
     arguments = {'filename': observation_file,
+                 'waterfall': waterfall_file,
                  'rx_device': client_settings.RX_DEVICE,
                  'center_freq': str(freq)}
     arg_string = ' '
     arg_string += '--rx-sdr-device=' + arguments['rx_device'] + ' '
     arg_string += '--file-path=' + arguments['filename'] + ' '
+    arg_string += '--waterfall-file-path=' + arguments['waterfall'] + ' '
     arg_string += '--rx-freq=' + arguments['center_freq'] + ' '
     logger.info('Starting GNUradio python script')
     proc = subprocess.Popen([client_settings.GNURADIO_SCRIPT_FILENAME + " " + arg_string], shell=True)


### PR DESCRIPTION
Changes in this commit will give the gr script the waterfall data filename, then run a function after oggenc to gnuplot the waterfall data resulting in a png file that is ready to be uploaded to the network.

This is just the creation of the waterfall, work to upload it will wait on satnogs/satnogs-network#276 and is most of the work necessary for satnogs/satnogs-client#42

There is one block in tasks.py post_data() that skips waterfall files for now, this will need replaced by API code when the time is right.

Requires gr-satnogs new enough to support waterfall sink (dev)

<!---
@huboard:{"custom_state":"archived"}
-->
