### PR TITLE
Push waterfall images to network

### DIFF
--- a/satnogsclient/scheduler/tasks.py
+++ b/satnogsclient/scheduler/tasks.py
@@ -84,16 +84,13 @@ def post_data():
         # Ignore files in receiving state
         if f.startswith('receiving'):
             continue
-
-        # temporary skip of waterfall until we integrate with Network
-        # TODO replace with network API code for waterfall
-        if f.startswith('waterfall'):
-            continue
-
         observation_id = f.split('_')[1]
         logger.info('Trying to PUT observation data for id: {0}'.format(observation_id))
         file_path = os.path.join(*[settings.OUTPUT_PATH, f])
-        observation = {'payload': open(file_path, 'rb')}
+        if f.startswith('satnogs'):
+            observation = {'payload': open(file_path, 'rb')}
+        elif f.startswith('waterfall'):
+            observation = {'waterfall': open(file_path, 'rb')}
         url = urljoin(base_url, observation_id)
         if not url.endswith('/'):
             url += '/'


### PR DESCRIPTION
When post_data cycles through files in /data/ looking for anything not 'receiving_', determines if the file is a waterfall or audio file and posts to network API accordingly.

<!---
@huboard:{"custom_state":"archived"}
-->
