### PR TITLE
fix for ChunkedEncodingError

### DIFF
--- a/satnogsclient/scheduler/tasks.py
+++ b/satnogsclient/scheduler/tasks.py
@@ -101,7 +101,8 @@ def post_data():
         logger.debug('Observation file: {0}'.format(observation))
         response = requests.put(url, headers=headers,
                                 files=observation,
-                                verify=settings.SATNOGS_VERIFY_SSL)
+                                verify=settings.SATNOGS_VERIFY_SSL,
+                                stream=True)
         if response.status_code == 200:
             logger.info('Success: status code 200')
             dst = os.path.join(settings.SATNOGS_COMPLETE_OUTPUT_PATH, f)


### PR DESCRIPTION
With a recent upstream network change, any long files sent via post_data would seem to make it to the end but then would throw a ChunkedEncodingError, never succeeding. I'm still not sure why that happened, but setting stream=True for requests.put fixes the issue.