### PR TITLE
Fix frequency error in manual observation

### DIFF
--- a/satnogsclient/scheduler/tasks.py
+++ b/satnogsclient/scheduler/tasks.py
@@ -63,7 +63,10 @@ def spawn_observer(*args, **kwargs):
     if 'user_args' in obj:
         user_args = obj['user_args']
         script_name = obj['script_name']
-        frequency = 100e6
+        if '--rx-freq=' in user_args:
+            frequency = int(user_args.split('--rx-freq=')[1].split(' ')[0])
+        else:
+            frequency = 100e6
     else:
         user_args = ""
         script_name = ""


### PR DESCRIPTION
During manual observation, the client was not aware of the frequency the device tuned to which resulted in bogus frequency information from rigctld to gr-satnogs. This Pull Request fixes that. The client now checks whether the user added the argument '--rx-freq' during scheduling of observation in the UI and passes that frequency to the rigctl daemon.