### PR TITLE
Select CW demod script when mode=CW

### DIFF
--- a/satnogsclient/observer/observer.py
+++ b/satnogsclient/observer/observer.py
@@ -218,7 +218,7 @@ class Observer:
         self.run_rig()
         # Polling gnuradio process status
         self.poll_gnu_proc_status()
-        if "satnogs_fm_demod.py" in settings.GNURADIO_SCRIPT_FILENAME:
+        if "satnogs_generic_iq_receiver.py" not in settings.GNURADIO_SCRIPT_FILENAME:
             logger.info('Rename encoded file for uploading.')
             self.rename_ogg_file()
             logger.info('Creating waterfall plot.')

--- a/satnogsclient/scheduler/tasks.py
+++ b/satnogsclient/scheduler/tasks.py
@@ -69,8 +69,11 @@ def spawn_observer(*args, **kwargs):
             frequency = 100e6
     else:
         user_args = ""
-        script_name = ""
         frequency = obj['frequency']
+    script_name = settings.GNURADIO_FM_SCRIPT_FILENAME
+    if 'mode' in obj:
+        if obj['mode'] == "CW":
+            script_name = settings.GNURADIO_CW_SCRIPT_FILENAME
     setup_kwargs = {
         'observation_id': obj['id'],
         'tle': tle,

--- a/satnogsclient/settings.py
+++ b/satnogsclient/settings.py
@@ -42,6 +42,8 @@ GNURADIO_UDP_PORT = 16886
 GNURADIO_IP = '127.0.0.1'
 GNURADIO_SCRIPT_PATH = ['/usr/bin', '/usr/local/bin']
 GNURADIO_SCRIPT_FILENAME = 'satnogs_fm_demod.py'
+GNURADIO_FM_SCRIPT_FILENAME = 'satnogs_fm_demod.py'
+GNURADIO_CW_SCRIPT_FILENAME = 'satnogs_cw_demod.py'
 SATNOGS_RX_DEVICE = environ.get('SATNOGS_RX_DEVICE', 'rtlsdr')
 CURRENT_PASS_TCP_PORT = 5005
 


### PR DESCRIPTION
Instead of running CW captures through the satnogs_fm_demod.py script, we can run these observations through a script that is tailored to CW captures, satnogs_cw_demod.py