### PR TITLE
fix killing of gnuradio subprocesses

### DIFF
--- a/satnogsclient/observer/worker.py
+++ b/satnogsclient/observer/worker.py
@@ -5,6 +5,8 @@ import math
 import threading
 import time
 import json
+import os
+import signal
 
 from datetime import datetime
 
@@ -154,7 +156,7 @@ class Worker:
         logger.info('Tracking stopped.')
         self.is_alive = False
         if self._gnu_proc:
-            self._gnu_proc.terminate()
+            os.killpg(os.getpgid(self._gnu_proc.pid), signal.SIGKILL)
 
     def check_observation_end_reached(self):
         if datetime.now(pytz.utc) > self._observation_end:

--- a/satnogsclient/upsat/gnuradio_handler.py
+++ b/satnogsclient/upsat/gnuradio_handler.py
@@ -2,6 +2,7 @@ from satnogsclient.web.weblogger import WebLogger
 import logging
 import cPickle
 import subprocess
+import os
 
 from satnogsclient.upsat import packet_settings
 from satnogsclient import settings as client_settings
@@ -114,5 +115,6 @@ def exec_gnuradio(observation_file, waterfall_file, freq, user_args, script_name
     arg_string += rigctl_port
 
     logger.info('Starting GNUradio python script')
-    proc = subprocess.Popen([scriptname + " " + arg_string], shell=True)
+    proc = subprocess.Popen([scriptname + " " + arg_string], shell=True,
+                            preexec_fn=os.setsid)
     return proc


### PR DESCRIPTION
With Popen using shell=true, 2 processes are spawned off for the gnuradio listener. Through the terminate() method the parent process is killed but that does not always mean the child process is also killed, leaving a gnuradio script holding on to the SDR.

This change kills the entire process group instead of just the parent shell process. SIGKILL works fine in this case, no need for SIGTERM.

fixes satnogs/gr-satnogs#63
resolves satnogs/satnogs-client#253