### PR TITLE
Fix variable initialization issue when uploading

### DIFF
--- a/satnogsclient/scheduler/tasks.py
+++ b/satnogsclient/scheduler/tasks.py
@@ -108,6 +108,9 @@ def post_data():
             observation = {'payload': open(file_path, 'rb')}
         elif f.startswith('waterfall'):
             observation = {'waterfall': open(file_path, 'rb')}
+        else:
+            logger.debug('Ignore file: {0}', f)
+            continue
         url = urljoin(base_url, observation_id)
         if not url.endswith('/'):
             url += '/'


### PR DESCRIPTION
Not ignoring files that don't start with "satnogs" or "waterfall"
strings when uploading caused "not initialized variable" error.