### PR TITLE
Ignore 'receiving_waterfall' files in post_data()

### DIFF
--- a/satnogsclient/scheduler/tasks.py
+++ b/satnogsclient/scheduler/tasks.py
@@ -86,6 +86,7 @@ def post_data():
     for f in os.walk(settings.SATNOGS_OUTPUT_PATH).next()[2]:
         file_path = os.path.join(*[settings.SATNOGS_OUTPUT_PATH, f])
         if (f.startswith('receiving_satnogs') or
+                f.startswith('receiving_waterfall') or
                 os.stat(file_path).st_size == 0):
             continue
         observation_id = f.split('_')[1]


### PR DESCRIPTION
It looks like this was forgotten when waterfall support was added. Without this, the presence of raw waterfall data files will generate a bunch of "Trying to PUT observation data for id: waterfall" in the syslog :)