### PR TITLE
Fix hardcoded arguments for gnuradio scripts in gnuradio handler

### DIFF
--- a/satnogsclient/observer/observer.py
+++ b/satnogsclient/observer/observer.py
@@ -27,6 +27,8 @@ class Observer:
     _location = None
     _gnu_proc = None
 
+    _origin = None
+
     _observation_raw_file = None
     _observation_ogg_file = None
     _observation_waterfall_file = None
@@ -116,6 +118,14 @@ class Observer:
         self._frequency = frequency
 
     @property
+    def origin(self):
+        return self._origin
+
+    @origin.setter
+    def origin(self, origin):
+        self._origin = origin
+
+    @property
     def observation_raw_file(self):
         return self._observation_raw_file
 
@@ -147,7 +157,7 @@ class Observer:
     def observation_waterfall_png(self, observation_waterfall_png):
         self._observation_waterfall_png = observation_waterfall_png
 
-    def setup(self, observation_id, tle, observation_end, frequency, user_args, script_name):
+    def setup(self, observation_id, tle, observation_end, frequency, origin, user_args, script_name):
         """
         Sets up required internal variables.
         * returns True if setup is ok
@@ -161,6 +171,7 @@ class Observer:
         self.tle = tle
         self.observation_end = observation_end
         self.frequency = frequency
+        self.origin = origin
 
         not_completed_prefix = 'receiving_satnogs'
         completed_prefix = 'satnogs'
@@ -193,9 +204,8 @@ class Observer:
             self.observation_id,
             timestamp,
             'png')
-
         return all([self.observation_id, self.tle,
-                    self.observation_end, self.frequency,
+                    self.observation_end, self.frequency, self.origin,
                     self.observation_raw_file,
                     self.observation_ogg_file,
                     self.observation_waterfall_file,
@@ -208,6 +218,7 @@ class Observer:
         self._gnu_proc = gnuradio_handler.exec_gnuradio(
             self.observation_raw_file,
             self.observation_waterfall_file,
+            self.origin,
             self.frequency,
             self.user_args,
             self.script_name)

--- a/satnogsclient/scheduler/tasks.py
+++ b/satnogsclient/scheduler/tasks.py
@@ -59,30 +59,29 @@ def spawn_observer(*args, **kwargs):
         'lat': settings.SATNOGS_STATION_LAT,
         'elev': settings.SATNOGS_STATION_ELEV
     }
-    frequency = ""
-    if 'user_args' in obj:
+    frequency = 100e6
+    if obj['origin'] == 'manual':
         user_args = obj['user_args']
         script_name = obj['script_name']
         if '--rx-freq=' in user_args:
             frequency = int(user_args.split('--rx-freq=')[1].split(' ')[0])
-        else:
-            frequency = 100e6
     else:
         user_args = ""
         frequency = obj['frequency']
-    script_name = settings.GNURADIO_FM_SCRIPT_FILENAME
-    if 'mode' in obj:
-        if obj['mode'] == "CW":
-            script_name = settings.GNURADIO_CW_SCRIPT_FILENAME
-        elif obj['mode'] == "APT":
-            script_name = settings.GNURADIO_APT_SCRIPT_FILENAME
-        elif obj['mode'].startswith('BPSK'):
-            script_name = settings.GNURADIO_BPSK_SCRIPT_FILENAME
+        script_name = settings.GNURADIO_FM_SCRIPT_FILENAME
+        if 'mode' in obj:
+            if obj['mode'] == "CW":
+                script_name = settings.GNURADIO_CW_SCRIPT_FILENAME
+            elif obj['mode'] == "APT":
+                script_name = settings.GNURADIO_APT_SCRIPT_FILENAME
+            elif obj['mode'].startswith('BPSK'):
+                script_name = settings.GNURADIO_BPSK_SCRIPT_FILENAME
     setup_kwargs = {
         'observation_id': obj['id'],
         'tle': tle,
         'observation_end': end,
         'frequency': frequency,
+        'origin': obj['origin'],
         'user_args': user_args,
         'script_name': script_name
     }
@@ -167,6 +166,7 @@ def get_jobs():
         tasks.append(obj)
         start = parser.parse(obj['start'])
         job_id = str(obj['id'])
+        obj['origin'] = 'network'
         kwargs = {'obj': obj}
         logger.info('Adding new job: {0}'.format(job_id))
         logger.debug('Observation obj: {0}'.format(obj))
@@ -386,6 +386,7 @@ def kill_wod_thread():
 def add_observation(obj):
     start = parser.parse(obj['start'])
     job_id = str(obj['id'])
+    obj['origin'] = 'manual'
     kwargs = {'obj': obj}
     logger.info('Adding new job: {0}'.format(job_id))
     logger.debug('Observation obj: {0}'.format(obj))

--- a/satnogsclient/upsat/gnuradio_handler.py
+++ b/satnogsclient/upsat/gnuradio_handler.py
@@ -51,7 +51,7 @@ def read_from_gnuradio():
             logger.error('Ecss Dictionary not properly constructed. Error occured. Key \'ser_type\' not in dictionary')
 
 
-def exec_gnuradio(observation_file, waterfall_file, freq, user_args, script_name):
+def exec_gnuradio(observation_file, waterfall_file, origin, freq, user_args, script_name):
     arguments = {'filename': observation_file,
                  'waterfall': waterfall_file,
                  'rx_device': client_settings.SATNOGS_RX_DEVICE,
@@ -60,59 +60,23 @@ def exec_gnuradio(observation_file, waterfall_file, freq, user_args, script_name
                  'user_args': user_args,
                  'script_name': script_name}
     scriptname = arguments['script_name']
-    doppler_correction = ''
-    lo_offset = ''
-    rigctl_port = ''
-    rigctl_port = ''
-
+    arg_string = ' '
     if not scriptname:
         scriptname = client_settings.GNURADIO_SCRIPT_FILENAME
-    if user_args:
-        if '--file-path=' in user_args:
-            file_path = user_args.split('--file-path=')[1].split(' ')[0]
-        elif '--file-path=' not in user_args:
-            file_path = arguments['filename']
-        if '--waterfall-file-path=' in user_args:
-            waterfall_file_path = user_args.split('--waterfall-file-path=')[1].split(' ')[0]
-        elif '--waterfall-file-path=' not in user_args:
-            waterfall_file_path = arguments['waterfall']
-        if '--ppm=' in user_args:
-            ppm = user_args.split('--ppm=')[1].split(' ')[0]
-        elif '--ppm=' not in user_args:
-            ppm = str(arguments['ppm'])
-        if '--rx-freq=' in user_args:
-            rx_freq = user_args.split('--rx-freq=')[1].split(' ')[0]
-        elif '--rx-freq=' not in user_args:
-            rx_freq = arguments['center_freq']
-        if '--rx-sdr-device=' in user_args:
-            device = user_args.split('--rx-sdr-device=')[1].split(' ')[0]
-        elif '--rx-sdr-device=' not in user_args:
-            device = client_settings.SATNOGS_RX_DEVICE
-        if '--doppler-correction-per-sec' in user_args:
-            doppler_correction = '--doppler-correction-per-sec=' + user_args.split('--doppler-correction-per-sec=')[1].split(' ')[0] + ' '
-        if '--doppler-correction-per-sec' in user_args:
-            doppler_correction = '--doppler-correction-per-sec=' + user_args.split('--doppler-correction-per-sec=')[1].split(' ')[0] + ' '
-        if '--lo-offset' in user_args:
-            lo_offset = '--lo-offset=' + user_args.split('--lo-offset=')[1].split(' ')[0] + ' '
-        if '--rigctl-port' in user_args:
-            rigctl_port = '--rigctl-port=' + user_args.split('--rigctl-port=')[1].split(' ')[0] + ' '
-    else:
+    if origin == 'network':
         rx_freq = arguments['center_freq']
         device = client_settings.SATNOGS_RX_DEVICE
         file_path = arguments['filename']
         waterfall_file_path = arguments['waterfall']
         ppm = str(arguments['ppm'])
-
-    arg_string = ' '
-    arg_string += '--rx-sdr-device=' + device + ' '
-    arg_string += '--rx-freq=' + rx_freq + ' '
-    arg_string += '--file-path=' + file_path + ' '
-    if scriptname != 'satnogs_generic_iq_receiver.py':
-        arg_string += '--waterfall-file-path=' + waterfall_file_path + ' '
+        arg_string += '--rx-sdr-device=' + device + ' '
+        arg_string += '--rx-freq=' + rx_freq + ' '
+        arg_string += '--file-path=' + file_path + ' '
         arg_string += '--ppm=' + ppm + ' '
-    arg_string += doppler_correction
-    arg_string += lo_offset
-    arg_string += rigctl_port
+        if arguments['waterfall'] != "":
+            arg_string += '--waterfall-file-path=' + waterfall_file_path + ' '
+    else:
+        arg_string = user_args
 
     logger.info('Starting GNUradio python script')
     proc = subprocess.Popen([scriptname + " " + arg_string], shell=True,


### PR DESCRIPTION
In gnuradio handler there are arguments for the gnuradio scripts that are added to every observation and every script. The problem is that not all of these arguments are supported by all scripts. The noaa_apt_decoder script for example does not have an argument named '--file-path=' although it is currently passed as argument. With this fix the manual observations are separated from the network observations so the user has complete control over the passed arguments from the corresponding field in the UI,since only these arguments are passed to the script and not the hardcoded ones of the current version. Also some unnecessary code from the gnuradio handler was removed.